### PR TITLE
smaller, younger and less honkin' tzimisce discipline buff

### DIFF
--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -1283,7 +1283,7 @@
 						qdel(target)
 		else
 			target.emote("scream")
-			target.apply_damage(10*level_casting, BRUTE, BODY_ZONE_CHEST)
+			target.apply_damage(20*level_casting, BRUTE, BODY_ZONE_CHEST)
 			if(prob(5*level_casting))
 				var/obj/item/bodypart/B = H.get_bodypart(pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG))
 				if(B)


### PR DESCRIPTION
## About The Pull Request

tzimisces can now force your bones to do the hokey pokey without your skin's consent

## Why It's Good For The Game

brings vicissitude as a combat discipline higher in-line with others to be used offensively

## Changelog
:cl:
balance; doubled vicissitude's damage from 10-per-level to 20-per-level. potence 5 deals 115 per unarmed hit, and the old vic felt underwhelming in comparison