### PR TITLE
npc_limit

### DIFF
--- a/code/controllers/subsystem/humannpcpool.dm
+++ b/code/controllers/subsystem/humannpcpool.dm
@@ -37,7 +37,11 @@ SUBSYSTEM_DEF(humannpcpool)
 		NPC.handle_automated_movement()
 
 /datum/controller/subsystem/humannpcpool/proc/npclost()
-	var/atom/kal = pick(GLOB.npc_spawn_points)
-	var/NEPIS = pick(/mob/living/carbon/human/npc/police, /mob/living/carbon/human/npc/bandit, /mob/living/carbon/human/npc/hobo, /mob/living/carbon/human/npc/walkby, /mob/living/carbon/human/npc/business)
-	new NEPIS(get_turf(kal))
-	log_world("new npc spawned")
+	if(length(GLOB.npc_list) < 50)
+		var/atom/kal = pick(GLOB.npc_spawn_points)
+		var/NEPIS = pick(/mob/living/carbon/human/npc/police, /mob/living/carbon/human/npc/bandit, /mob/living/carbon/human/npc/hobo, /mob/living/carbon/human/npc/walkby, /mob/living/carbon/human/npc/business)
+		new NEPIS(get_turf(kal))
+		log_world("new npc spawned")
+		to_chat(usr, "<An npc has spawned.</span>")
+	else
+		return


### PR DESCRIPTION
## About The Pull Request

Non-starting NPCs will be more rare now. There can only exist a certain number of them on the map at a time.

## Why It's Good For The Game

Better performance. Less bloodshed.

## Changelog
:cl:
tweak: NPCs won't respawn if there are more than 50 of them. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
