### PR TITLE
Remove Lewd Messages tab from tgui

### DIFF
--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -97,12 +97,6 @@ export const MESSAGE_TYPES = [
     selector: '.danger',
   },
   {
-    type: 'lovetype',
-    name: 'Lewd messages',
-    description: 'You came!',
-    selector: '.userlove, .love',
-  },
-  {
     type: MESSAGE_TYPE_UNKNOWN,
     name: 'Unsorted',
     description: 'Everything we could not sort, always enabled',


### PR DESCRIPTION
## About The Pull Request
Holy fucking shit, why do we have this? Removes the "Lewd Messages" tab from fancychat's tab feature. 

## Why It's Good For The Game
We are not an ERP server. We have none of these.

## Changelog
:cl:
del: Lewd Messages tab in fancychat.
/:cl:
