### PR TITLE
Obtenebration balances

### DIFF
--- a/code/modules/vtmb/vampire_clane/lasombra.dm
+++ b/code/modules/vtmb/vampire_clane/lasombra.dm
@@ -56,7 +56,7 @@
 //	animate(H, color = "#000000", time = 10, loop = 1)
 	if(H.CheckEyewitness(H, H, 7, FALSE))
 		H.AdjustMasquerade(-1)
-	spawn(100)
+	spawn(300)
 		if(H)
 			playsound(H.loc, 'sound/magic/voidblink.ogg', 50, FALSE)
 			for(var/obj/item/melee/vampirearms/knife/gangrel/lasombra/G in H.contents)
@@ -89,7 +89,7 @@
 	animate(H, color = "#000000", time = 10, loop = 1)
 	if(H.CheckEyewitness(H, H, 7, FALSE))
 		H.AdjustMasquerade(-1)
-	spawn(100)
+	spawn(400)
 		if(H)
 			playsound(H.loc, 'sound/magic/voidblink.ogg', 50, FALSE)
 			H.physiology.damage_resistance -= 75


### PR DESCRIPTION
## About The Pull Request

Changes the time of several Obtenebration actions to appropriately represent levels and blood costs.

## Why It's Good For The Game

Previously, both 3rd and 4th level Obtenebration actions lasted TEN SECONDS. That is terrible.

## Changelog
:cl:
changed Summon Tentacles duration from 10 seconds to 30 seconds
changed Shadow Armor duration from 10 seconds to 40 seconds
/:cl: