### PR TITLE
Cleaned up server log + added default case for Masquerade

### DIFF
--- a/code/controllers/subsystem/humannpcpool.dm
+++ b/code/controllers/subsystem/humannpcpool.dm
@@ -45,6 +45,5 @@ SUBSYSTEM_DEF(humannpcpool)
 		var/atom/kal = pick(GLOB.npc_spawn_points)
 		var/NEPIS = pick(/mob/living/carbon/human/npc/police, /mob/living/carbon/human/npc/bandit, /mob/living/carbon/human/npc/hobo, /mob/living/carbon/human/npc/walkby, /mob/living/carbon/human/npc/business)
 		new NEPIS(get_turf(kal))
-		log_world("new npc spawned")
 	else
 		return

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -559,9 +559,9 @@
 	if(istype(src, /mob/dead/observer))
 		O = src
 
-	var/add_delay = 2
+	var/add_delay = 0.1
 
-	if(O != null)
+	if(O.movement_delay != 0)
 		add_delay = O.movement_delay
 
 	if(old_move_delay + (add_delay*MOVEMENT_DELAY_BUFFER_DELTA) + MOVEMENT_DELAY_BUFFER > world.time)
@@ -572,5 +572,3 @@
 	..()
 
 	glide_size = (world.icon_size / ceil(add_delay / world.tick_lag))
-
-	// to_chat(src, "Observer Movement called, add_delay = [add_delay], move_delay = [move_delay]")

--- a/code/modules/vtmb/gamemodes/masquerade.dm
+++ b/code/modules/vtmb/gamemodes/masquerade.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(masquerade)
 			return "MODERATE VIOLATION"
 		if(501 to 750)
 			return "SUSPICIOUS"
-		if(751 to 1000)
+		else
 			return "STABLE"
 
 /datum/controller/subsystem/masquerade/fire()
@@ -37,7 +37,7 @@ SUBSYSTEM_DEF(masquerade)
 			shit_happens = "moderate"
 		if(501 to 750)
 			shit_happens = "slightly"
-		if(751 to 1000)
+		else
 			shit_happens = "stable"
 
 	if(last_level != shit_happens)
@@ -47,13 +47,13 @@ SUBSYSTEM_DEF(masquerade)
 				if(iskindred(H) || isghoul(H))
 					switch(last_level)
 						if("stable")
-							to_chat(H, "Night becomes clear, nothing can threat the Masquerade...")
+							to_chat(H, "The night becomes clear. Nothing can threaten the Masquerade.")
 						if("slightly")
 							to_chat(H, "Something is going wrong here...")
 						if("moderate")
 							to_chat(H, "People start noticing...")
 						if("breach")
-							to_chat(H, "Masquerade is about to fall...")
+							to_chat(H, "The Masquerade is about to fall...")
 
 	if(total_level <= 250)
 		for(var/mob/living/carbon/human/H in GLOB.player_list)


### PR DESCRIPTION
## About The Pull Request
Minor fixes so that observer movement doesn't constantly try to divide by 0, and NPCs don't print out a message whenever they spawn. Also makes the Masquerade value display as "stable" when it's above 1000 to prevent weird bugs with it going over. Will try to make sure it never goes over in the future, but this was just necessary to improve the code.

## Why It's Good For The Game
It's easier to see what's going wrong when there isn't 1000 runtimes every time a ghost moves! Also allows for Masquerade to still mostly work when overflowing.

## Changelog
:cl:
fix: Masquerade values above 1000 now display as stable.
refactor: No more log spam from observer moment and NPC spawning!
/:cl:
