### PR TITLE
Athletics skill

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -56,6 +56,7 @@
 #define COMSIG_KB_MOB_CYCLEINTENTRIGHT_DOWN "keybinding_mob_cycleintentright_down"
 #define COMSIG_KB_MOB_CYCLEINTENTLEFT_DOWN "keybinding_mob_cycleintentleft_down"
 #define COMSIG_KB_MOB_SWAPHANDS_DOWN "keybinding_mob_swaphands_down"
+#define COMSIG_KB_MOB_JUMP_DOWN "keybinding_mob_jump_down"
 #define COMSIG_KB_MOB_ACTIVATEINHAND_DOWN "keybinding_mob_activateinhand_down"
 #define COMSIG_KB_MOB_DROPITEM_DOWN "keybinding_mob_dropitem_down"
 #define COMSIG_KB_MOB_TOGGLEMOVEINTENT_DOWN "keybinding_mob_togglemoveintent_down"

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -424,7 +424,7 @@
 	. = SEND_SIGNAL(src, COMSIG_MOB_MIDDLECLICKON, A, params)
 	if(. & COMSIG_MOB_CANCEL_CLICKON)
 		return
-	swap_hand()
+	jump(A)
 
 /**
  * Shift click
@@ -578,7 +578,7 @@
 	var/list/modifiers = params2list(params)
 	if(modifiers["middle"] && iscarbon(usr))
 		var/mob/living/carbon/C = usr
-		C.swap_hand()
+		C.jump(C.loc) //Calls (jump) instead of swap_hand()
 	else
 		var/turf/T = params2turf(modifiers["screen-loc"], get_turf(usr.client ? usr.client.eye : usr), usr.client)
 		params += "&catcher=1"

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -51,7 +51,7 @@
 	return TRUE
 
 /datum/keybinding/mob/swap_hands
-	hotkey_keys = list("X", "Northeast") // PAGEUP
+	hotkey_keys = list("X") // PAGEUP
 	name = "swap_hands"
 	full_name = "Swap hands"
 	description = ""
@@ -64,6 +64,21 @@
 	var/mob/M = user.mob
 	M.swap_hand()
 	return TRUE
+
+/datum/keybinding/mob/jump
+    hotkey_keys = list("Northeast") // MMB
+    name = "jump"
+    full_name = "Jump"
+    description = "Makes your character jump."
+    keybind_signal = COMSIG_KB_MOB_JUMP_DOWN
+
+/datum/keybinding/mob/jump/down(client/user)
+    . = ..()
+    if(.)
+        return
+    var/mob/M = user.mob
+    M.jump(M.loc) // Call the jump function when MMB is pressed
+    return TRUE
 
 /datum/keybinding/mob/activate_inhand
 	hotkey_keys = list("Z", "Southeast") // Southeast = PAGEDOWN

--- a/code/modules/ziggers/quirks.dm
+++ b/code/modules/ziggers/quirks.dm
@@ -180,14 +180,14 @@ Dancer
 	lose_text = "<span class='warning'>You don't feel like you can burn without consequences anymore.</span>"
 	allowed_species = list("Vampire")
 
-/datum/quirk/acrobatic
+/*/datum/quirk/acrobatic
 	name = "Acrobatic"
 	desc = "You know a couple of acrobatic moves."
 	value = 3
 	mob_trait = TRAIT_ACROBATIC
 	gain_text = "<span class='notice'>You feel like you can jump higher.</span>"
 	lose_text = "<span class='warning'>Now you aren't as agile as you were.</span>"
-
+*/
 /datum/quirk/acrobatic/on_spawn()
 	var/mob/living/carbon/H = quirk_holder
 	var/datum/action/acrobate/DA = new()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Implements jumping ability in-game. Press MMB at something and you will jump towards it. Maximum default distance is 1, but numbers round up - each physique point adds 0.75 to the number. So the minimum you will jump is 2 tiles, and the maximum is going to be 5. Will be switched up to have more variability and randomness based on your athletics + strength/dexterity in the future, but for the time being it works just fine. Also removed acrobat quirk as it is now replaced by this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It will lead to making other skills useful - athletics, then attributes, strength and dexterity. Plus, you can jump into people to tackle them. It's awesome.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Jumping ability that can be used with mmb.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
