### PR TITLE
Allows Nosferatu to ventcrawl as a treat

### DIFF
--- a/code/modules/vtmb/vampire_clane/nosferatu.dm
+++ b/code/modules/vtmb/vampire_clane/nosferatu.dm
@@ -31,6 +31,7 @@
 	H.apply_overlay(UPPER_EARS_LAYER)
 	var/obj/item/organ/eyes/night_vision/NV = new()
 	NV.Insert(H, TRUE, FALSE)
+	H.ventcrawler = VENTCRAWLER_ALWAYS
 
 /datum/vampireclane/nosferatu/post_gain(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
## About The Pull Request

This allows Nosferatu to ventcrawl, I did not implement any map changes for that to have a use yet, mainly because I'm an atrocious mapper. 

But I may or may not add an alternate sprite for a scrubber that mimics a sewer pipe AND bribe @CatandWet to contribute the map changes.

## Why It's Good For The Game

Nosferatu Highway is the way forward people, just think about it! Also it's a cool thing for a clan that can't really go into public spaces.

**Behold**, the Nosferatu in your pipes!
https://github.com/user-attachments/assets/514990bc-4835-4780-b0f7-a2ba0fe03e54

## Changelog
:cl:
add: Added ventcrawler trait to Nosferatu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
