### PR TITLE
Enable disciplines while lying down

### DIFF
--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -1,20 +1,34 @@
 /datum/discipline
+	///Name of this Discipline.
 	var/name = "Vampiric Discipline"
+	///Text description of this Discipline.
 	var/desc = "Discipline with powers such as..."
+	///Icon for this Discipline as in disciplines.dmi
 	var/icon_state
+	///Cost in blood points of activating this Discipline.
 	var/cost = 2
+	///Whether this Discipline is ranged.
 	var/ranged = FALSE
+	///The range from which this Discipline can be used on a target.
 	var/range_sh = 8
+	///Duration of the Discipline.
 	var/delay = 5
+	///Whether this Discipline causes a Masquerade breach when used in front of mortals.
 	var/violates_masquerade = FALSE
+	///What rank, or how many dots the caster has in this Discipline.
 	var/level = 1
+	///The sound that plays when any power of this Discipline is activated.
 	var/activate_sound = 'code/modules/wod13/sounds/bloodhealing.ogg'
+	///Whether this Discipline's cooldowns are multipled by the level it's being casted at.
 	var/leveldelay = FALSE
+	///Whether this Discipline aggroes NPC targets.
 	var/fearless = FALSE
 
-	var/level_casting = 1	//which level we want to cast
-	var/clane_restricted = FALSE	//Only for specified clans
-	var/clane_exclusion = FALSE
+	///What rank of this Discipline is currently being casted.
+	var/level_casting = 1
+	///Whether this Discipline is exclusive to one Clan.
+	var/clane_restricted = FALSE
+	///Whether this Discipline is restricted from affecting dead people.
 	var/dead_restricted = TRUE
 
 /datum/discipline/proc/post_gain(var/mob/living/carbon/human/H)

--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -129,7 +129,7 @@
 			return
 
 /datum/discipline/proc/check_activated(var/mob/living/target, var/mob/living/carbon/human/caster)
-	if(caster.stat >= 2 || caster.IsSleeping() || caster.IsUnconscious() || caster.IsParalyzed() || caster.IsKnockdown() || caster.IsStun() || HAS_TRAIT(caster, TRAIT_RESTRAINED) || !isturf(caster.loc))
+	if(caster.stat >= 2 || caster.IsSleeping() || caster.IsUnconscious() || caster.IsParalyzed() || caster.IsStun() || HAS_TRAIT(caster, TRAIT_RESTRAINED) || !isturf(caster.loc))
 		return FALSE
 	var/plus = 0
 	if(HAS_TRAIT(caster, TRAIT_HUNGRY))


### PR DESCRIPTION
## About The Pull Request
Adds documentation to variables used in /datum/discipline, and removes the check while casting to see whether the caster is currently knocked down. This lets people use Disciplines even when on the floor from something like Potence.

## Why It's Good For The Game
The meta is currently just knocking someone down and beating them up while they're incapable of resisting in any way. It's time to let go of that nonsense.

## Changelog
:cl:
tweak: You can now use Disciplines while knocked down. No more helplessly lying on the floor after getting Potence punched!
/:cl: