### PR TITLE
De-Azanealification of Baali

### DIFF
--- a/code/modules/vtmb/vampire_clane/baali.dm
+++ b/code/modules/vtmb/vampire_clane/baali.dm
@@ -3,7 +3,7 @@
 	desc = "The Baali are a bloodline of vampires associated with demon worship. Because of their affinity with the unholy, the Baali are particularly vulnerable to holy iconography, holy ground and holy water. They are highly vulnerable to True Faith."
 	curse = "Fear of the Religion."
 	clane_disciplines = list(/datum/discipline/obfuscate = 1,
-														/datum/discipline/obtenebration = 2,
+														/datum/discipline/presence = 2,
 														/datum/discipline/daimonion = 3)
 	male_clothes = "/obj/item/clothing/under/vampire/baali"
 	female_clothes = "/obj/item/clothing/under/vampire/baali/female"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
In this pull request I do a magic trick that makes it so Baali are actually Baali! I achieve this mistifying effect by swapping their second discipline from Obtenebration to Presence!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Obtenebration is super wack in-game, also lore accuracy. Also also, back in the Age of Flav Baali donators chose Obtenebration because it was shrimply better than Presence.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Changed Baali's second discipline to Presence.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
