### PR TITLE
big deals fat wheels

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -8,11 +8,11 @@
 /// Standard backpacks can carry tiny, small & normal items, (e.g. fire extinguisher, stun baton, gas mask, metal sheets)
 #define WEIGHT_CLASS_NORMAL   3
 /// Items that can be weilded or equipped but not stored in an inventory, (e.g. defibrillator, backpack, space suits)
-#define WEIGHT_CLASS_BULKY    4
+#define WEIGHT_CLASS_BULKY    16
 /// Usually represents objects that require two hands to operate, (e.g. shotgun, two-handed melee weapons)
-#define WEIGHT_CLASS_HUGE     5
+#define WEIGHT_CLASS_HUGE     32
 /// Essentially means it cannot be picked up or placed in an inventory, (e.g. mech parts, safe)
-#define WEIGHT_CLASS_GIGANTIC 6
+#define WEIGHT_CLASS_GIGANTIC 64
 
 //Inventory depth: limits how many nested storage items you can access directly.
 //1: stuff in mob, 2: stuff in backpack, 3: stuff in box in backpack, etc

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -352,6 +352,7 @@
 /obj/item/storage/backpack/duffelbag/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_w_class = WEIGHT_CLASS_BULKY
 	STR.max_combined_w_class = 30
 
 /obj/item/storage/backpack/duffelbag/cursed

--- a/code/modules/wod13/car.dm
+++ b/code/modules/wod13/car.dm
@@ -107,8 +107,8 @@
 	var/last_beep = 0
 
 	var/component_type = /datum/component/storage/concrete
-	var/baggage_limit = 20
-	var/baggage_max = WEIGHT_CLASS_NORMAL
+	var/baggage_limit = 30
+	var/baggage_max = WEIGHT_CLASS_BULKY
 
 	var/exploded = FALSE
 	var/beep_sound = 'code/modules/wod13/sounds/beep.ogg'
@@ -718,6 +718,8 @@
 	last_dir = WEST
 	beep_sound = 'code/modules/wod13/sounds/migalka.ogg'
 	access = "police"
+	baggage_limit = 50
+	baggage_max = WEIGHT_CLASS_BULKY
 	var/color_blue = FALSE
 	var/last_color_change = 0
 
@@ -747,6 +749,8 @@
 	moving_dir = WEST
 	last_dir = WEST
 	access = "taxi"
+	baggage_limit = 40
+	baggage_max = WEIGHT_CLASS_BULKY
 
 /obj/vampire_car/track
 	icon_state = "track"
@@ -756,7 +760,7 @@
 	moving_dir = WEST
 	last_dir = WEST
 	access = "none"
-	baggage_limit = 40
+	baggage_limit = 100
 	baggage_max = WEIGHT_CLASS_BULKY
 
 /obj/vampire_car/track/Initialize()
@@ -766,6 +770,7 @@
 
 /obj/vampire_car/track/volkswagen
 	icon_state = "volkswagen"
+	baggage_limit = 60
 
 /obj/vampire_car/track/ambulance
 	icon_state = "ambulance"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Alters bulkier and onwards' item weights to allow..
All cars' trunks can now accommodate at least one bulky item (duffelbag full of junk, long rifles etc.)
Trucks and ambulances can carry a LOT now, wagens slightly less for back alley smuggling purposes.
Duffels can now also carry a single long gun.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More reasonable concealment options.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: changed around a few numbers 
balance: cars feel more purposeful
fix: having very little reason to use a duffelbag

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
