### PR TITLE
Less Smoking Lung Damage

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -262,8 +262,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				reagents.expose(C, INGEST, fraction)
 				var/obj/item/organ/lungs/L = C.getorganslot(ORGAN_SLOT_LUNGS)
 				if(L && !(L.organ_flags & ORGAN_SYNTHETIC))
-					if(!iskindred(src)) //Should make cigs not do lung damage to kindred
-						C.adjustOrganLoss(ORGAN_SLOT_LUNGS, lung_harm)
 				if(!reagents.trans_to(C, to_smoke))
 					reagents.remove_any(to_smoke)
 				return

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -262,7 +262,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				reagents.expose(C, INGEST, fraction)
 				var/obj/item/organ/lungs/L = C.getorganslot(ORGAN_SLOT_LUNGS)
 				if(L && !(L.organ_flags & ORGAN_SYNTHETIC))
-					C.adjustOrganLoss(ORGAN_SLOT_LUNGS, lung_harm)
+					if(!iskindred(src)) //Should make cigs not do lung damage to kindred
+						C.adjustOrganLoss(ORGAN_SLOT_LUNGS, lung_harm)
 				if(!reagents.trans_to(C, to_smoke))
 					reagents.remove_any(to_smoke)
 				return

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -262,6 +262,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				reagents.expose(C, INGEST, fraction)
 				var/obj/item/organ/lungs/L = C.getorganslot(ORGAN_SLOT_LUNGS)
 				if(L && !(L.organ_flags & ORGAN_SYNTHETIC))
+					C.adjustOrganLoss(ORGAN_SLOT_LUNGS, lung_harm)
 				if(!reagents.trans_to(C, to_smoke))
 					reagents.remove_any(to_smoke)
 				return

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -141,7 +141,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/chem_volume = 30
 	var/smoke_all = FALSE /// Should we smoke all of the chems in the cig before it runs out. Splits each puff to take a portion of the overall chems so by the end you'll always have consumed all of the chems inside.
 	var/list/list_reagents = list(/datum/reagent/drug/nicotine = 15)
-	var/lung_harm = 1 //How bad it is for you
+	var/lung_harm = 0.1 //How bad it is for you //Edited to lower from 1 to 0.1
 
 /obj/item/clothing/mask/cigarette/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is huffing [src] as quickly as [user.p_they()] can! It looks like [user.p_theyre()] trying to give [user.p_them()]self cancer.</span>")

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -327,29 +327,35 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/space_cigarette
 	desc = "A Space Cigarette brand cigarette."
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/dromedary
 	desc = "A DromedaryCo brand cigarette. Contrary to popular belief, does not contain Calomel, but is reported to have a watery taste."
 	list_reagents = list(/datum/reagent/drug/nicotine = 13, /datum/reagent/water = 5) //camel has water
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/uplift
 	desc = "An Uplift Smooth brand cigarette. Smells refreshing."
 	list_reagents = list(/datum/reagent/drug/nicotine = 13, /datum/reagent/consumable/menthol = 5)
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/robust
 	desc = "A Robust brand cigarette."
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/robustgold
 	desc = "A Robust Gold brand cigarette."
 	list_reagents = list(/datum/reagent/drug/nicotine = 15, /datum/reagent/gold = 3) // Just enough to taste a hint of expensive metal.
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/carp
 	desc = "A Carp Classic brand cigarette. A small label on its side indicates that it does NOT contain carpotoxin."
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/syndicate
 	desc = "An unknown brand cigarette."
@@ -358,16 +364,19 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	smoke_all = TRUE
 	list_reagents = list(/datum/reagent/drug/nicotine = 10, /datum/reagent/medicine/omnizine = 15)
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	lung_harm = 0
 
 /obj/item/clothing/mask/cigarette/shadyjims
 	desc = "A Shady Jim's Super Slims cigarette."
 	list_reagents = list(/datum/reagent/drug/nicotine = 15, /datum/reagent/toxin/plantbgone = 1, /datum/reagent/toxin = 1.5)
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/xeno
 	desc = "A Xeno Filtered brand cigarette."
 	list_reagents = list (/datum/reagent/drug/nicotine = 20, /datum/reagent/medicine/omnizine = 15)
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	lung_harm = 0.1
 
 // Rollies.
 
@@ -384,6 +393,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	chem_volume = 50
 	list_reagents = null
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
+	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/rollie/Initialize()
 	. = ..()
@@ -454,12 +464,14 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "candyoff"
 	type_butt = /obj/item/food/candy_trash
 	list_reagents = list(/datum/reagent/consumable/sugar = 10, /datum/reagent/consumable/caramel = 10)
+	lung_harm = 0 //There's not even nicotine in this?
 
 /obj/item/clothing/mask/cigarette/candy/nicotine
 	desc = "For all ages*! Doesn't contain any* amount of nicotine. Health and safety risks can be read on the tip of the cigarette."
 	type_butt = /obj/item/food/candy_trash/nicotine
 	list_reagents = list(/datum/reagent/consumable/sugar = 10, /datum/reagent/consumable/caramel = 10, /datum/reagent/drug/nicotine = 20) //oh no!
 	smoke_all = TRUE //timmy's not getting out of this one
+	lung_harm = 0.1
 
 /obj/item/cigbutt/roach
 	name = "roach"
@@ -487,6 +499,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	smoketime = 11 * 60
 	chem_volume = 40
 	list_reagents = list(/datum/reagent/drug/nicotine = 25)
+	lung_harm = 0.2
 
 /obj/item/clothing/mask/cigarette/cigar/cohiba
 	name = "\improper Cohiba Robusto cigar"
@@ -535,6 +548,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	smoketime = 0
 	chem_volume = 100
 	list_reagents = null
+	lung_harm = 0.1
 	var/packeditem = FALSE
 
 /obj/item/clothing/mask/cigarette/pipe/Initialize()

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -327,35 +327,29 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/cigarette/space_cigarette
 	desc = "A Space Cigarette brand cigarette."
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
-	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/dromedary
 	desc = "A DromedaryCo brand cigarette. Contrary to popular belief, does not contain Calomel, but is reported to have a watery taste."
 	list_reagents = list(/datum/reagent/drug/nicotine = 13, /datum/reagent/water = 5) //camel has water
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
-	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/uplift
 	desc = "An Uplift Smooth brand cigarette. Smells refreshing."
 	list_reagents = list(/datum/reagent/drug/nicotine = 13, /datum/reagent/consumable/menthol = 5)
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
-	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/robust
 	desc = "A Robust brand cigarette."
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
-	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/robustgold
 	desc = "A Robust Gold brand cigarette."
 	list_reagents = list(/datum/reagent/drug/nicotine = 15, /datum/reagent/gold = 3) // Just enough to taste a hint of expensive metal.
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
-	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/carp
 	desc = "A Carp Classic brand cigarette. A small label on its side indicates that it does NOT contain carpotoxin."
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
-	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/syndicate
 	desc = "An unknown brand cigarette."
@@ -364,19 +358,16 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	smoke_all = TRUE
 	list_reagents = list(/datum/reagent/drug/nicotine = 10, /datum/reagent/medicine/omnizine = 15)
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
-	lung_harm = 0
 
 /obj/item/clothing/mask/cigarette/shadyjims
 	desc = "A Shady Jim's Super Slims cigarette."
 	list_reagents = list(/datum/reagent/drug/nicotine = 15, /datum/reagent/toxin/plantbgone = 1, /datum/reagent/toxin = 1.5)
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
-	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/xeno
 	desc = "A Xeno Filtered brand cigarette."
 	list_reagents = list (/datum/reagent/drug/nicotine = 20, /datum/reagent/medicine/omnizine = 15)
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
-	lung_harm = 0.1
 
 // Rollies.
 
@@ -393,7 +384,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	chem_volume = 50
 	list_reagents = null
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
-	lung_harm = 0.1
 
 /obj/item/clothing/mask/cigarette/rollie/Initialize()
 	. = ..()
@@ -464,14 +454,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	icon_state = "candyoff"
 	type_butt = /obj/item/food/candy_trash
 	list_reagents = list(/datum/reagent/consumable/sugar = 10, /datum/reagent/consumable/caramel = 10)
-	lung_harm = 0 //There's not even nicotine in this?
 
 /obj/item/clothing/mask/cigarette/candy/nicotine
 	desc = "For all ages*! Doesn't contain any* amount of nicotine. Health and safety risks can be read on the tip of the cigarette."
 	type_butt = /obj/item/food/candy_trash/nicotine
 	list_reagents = list(/datum/reagent/consumable/sugar = 10, /datum/reagent/consumable/caramel = 10, /datum/reagent/drug/nicotine = 20) //oh no!
 	smoke_all = TRUE //timmy's not getting out of this one
-	lung_harm = 0.1
 
 /obj/item/cigbutt/roach
 	name = "roach"
@@ -499,7 +487,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	smoketime = 11 * 60
 	chem_volume = 40
 	list_reagents = list(/datum/reagent/drug/nicotine = 25)
-	lung_harm = 0.2
 
 /obj/item/clothing/mask/cigarette/cigar/cohiba
 	name = "\improper Cohiba Robusto cigar"
@@ -548,7 +535,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	smoketime = 0
 	chem_volume = 100
 	list_reagents = null
-	lung_harm = 0.1
 	var/packeditem = FALSE
 
 /obj/item/clothing/mask/cigarette/pipe/Initialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Alters smoking lung damage to give you about a tenth of what it normally does. That's it.

Not tested, but it's just a number change. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Trying to roleplay as a nicotine addicted kine? Time to not die after smoking three cigarettes!
Genuinely though, I do feel like smoking lung damage needs to be retuned at least slightly, actual numbers should be good to play with. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Smoking no longer deals excessive lung damage
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
