### PR TITLE
Rebalance Dominate

### DIFF
--- a/code/modules/vtmb/disciplines.dm
+++ b/code/modules/vtmb/disciplines.dm
@@ -443,8 +443,10 @@
 	. = ..()
 	if(target.spell_immunity)
 		return
-	var/mypower = 13-caster.generation+caster.social+caster.additional_mentality
-	var/theirpower = 13-target.generation+target.mentality+target.additional_mentality
+	if (caster.generation > target.generation) //fail if used on a lower generation
+		return
+	var/mypower = caster.social + caster.additional_social
+	var/theirpower = target.mentality + target.additional_mentality
 	if(theirpower > mypower)
 		to_chat(caster, "<span class='warning'>[target] is too powerful for you!</span>")
 		return


### PR DESCRIPTION
## About The Pull Request
Changes Dominate to be more tabletop-accurate, meaning that you cast it using your social attributes and you cannot cast it on people of a lower Generation. Generation no longer factors in besides that.

## Why It's Good For The Game
More tabletop accuracy is great, and this also makes it easier for humans to resist Dominate.

## Changelog
:cl:
balance: Dominate no longer works on lower Generations. Casting dominate now uses social.
/:cl:
